### PR TITLE
Bump GitHub Actions and enable Dependabot for uv + actions

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,23 @@
+version: 2
+updates:
+  - package-ecosystem: "uv"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    open-pull-requests-limit: 10
+    groups:
+      python-minor-patch:
+        update-types:
+          - "minor"
+          - "patch"
+
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    open-pull-requests-limit: 10
+    groups:
+      actions-minor-patch:
+        update-types:
+          - "minor"
+          - "patch"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,9 +10,9 @@ jobs:
     name: lint + type check
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@v6
 
-      - uses: astral-sh/setup-uv@v5
+      - uses: astral-sh/setup-uv@v8.1.0
         with:
           enable-cache: true
 
@@ -37,12 +37,12 @@ jobs:
         os: [ubuntu-latest, macos-latest, windows-latest]
         python-version: ["3.10", "3.11", "3.12", "3.13"]
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@v6
         with:
           # setuptools_scm needs the full history to derive the version
           fetch-depth: 0
 
-      - uses: astral-sh/setup-uv@v5
+      - uses: astral-sh/setup-uv@v8.1.0
         with:
           enable-cache: true
           python-version: ${{ matrix.python-version }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -10,18 +10,18 @@ jobs:
     name: Build sdist and wheel
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@v6
         with:
           fetch-depth: 0
 
-      - uses: astral-sh/setup-uv@v5
+      - uses: astral-sh/setup-uv@v8.1.0
         with:
           enable-cache: true
 
       - name: Build distributions
         run: uv build
 
-      - uses: actions/upload-artifact@v5
+      - uses: actions/upload-artifact@v7
         with:
           name: dist
           path: dist/
@@ -36,7 +36,7 @@ jobs:
     permissions:
       id-token: write
     steps:
-      - uses: actions/download-artifact@v5
+      - uses: actions/download-artifact@v8
         with:
           name: dist
           path: dist/
@@ -50,11 +50,11 @@ jobs:
     permissions:
       contents: write
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@v6
         with:
           fetch-depth: 0
 
-      - uses: actions/download-artifact@v5
+      - uses: actions/download-artifact@v8
         with:
           name: dist
           path: dist/


### PR DESCRIPTION
## Summary

- Bumps GitHub Actions versions that had fallen behind (all major releases reviewed for breaking changes — none relevant to this repo):
  - `actions/checkout` v5 → v6
  - `astral-sh/setup-uv` v5 → **v8.1.0** (v8 stopped publishing a floating major tag, so this pins to a full immutable release)
  - `actions/upload-artifact` v5 → v7
  - `actions/download-artifact` v5 → v8
- Adds `.github/dependabot.yml` covering the `uv` ecosystem (watches `pyproject.toml` / `uv.lock`) and `github-actions`, so workflow pins and dependencies stay current going forward. Minor/patch bumps are grouped to reduce PR noise.

## Context

Noticed two stale Dependabot PRs (#30, #33) targeting `Pipfile.lock`, which was removed during the uv migration — those are obsolete and will be closed separately. Python runtime/dev deps are all at latest per `uv pip list --outdated`.

## Test plan

- [ ] CI passes on this PR (covers the bumped `checkout` + `setup-uv` versions).
- [ ] Next tag-driven release exercises `upload-artifact@v7` / `download-artifact@v8` in `release.yml`.
- [ ] Dependabot picks up the new config and starts opening PRs for uv + actions.